### PR TITLE
fix manpage markup

### DIFF
--- a/grml2iso.8.txt
+++ b/grml2iso.8.txt
@@ -30,34 +30,34 @@ WRKDIR specifies the work directory for creating the filesystem.
 The work directory needs at least as much free disk space as the sum
 of all specified ISOs.
 
-  *\-o <target.iso>*::
+  *-o <target.iso>*::
 
 This option is mandatory and specifies where the resulting multiboot grml ISO
 should be placed. Note that (to avoid any possible data loss) grml2iso will exit
 if the specified target.iso exists already.
 
-  *\-c <directory>*::
+  *-c <directory>*::
 
 The content of the specified directory will be copied to the resulting
 multiboot grml ISO.
 
-  *\-b <boot params>*::
+  *-b <boot params>*::
 
 Use specified default bootoptions as default.
 
-  *\-f *::
+  *-f*::
 
 Force the program to run and overwrite an existing iso image.
 
-  *\-r <boot param>*::
+  *-r <boot param>*::
 
 Remove specified boot parameter from existing command line. Could be specified multiple times.
 
-  *\-p <grml2usb param>*::
+  *-p <grml2usb param>*::
 
 Execute grml2usb with the specified parameters. For a list of valid parameters have a look at the link:http://grml.org/grml2usb/[grml2usb webpage] or the grml2usb manpage
 
- *\-s <URI>*::
+  *-s <URI>*::
 
 Generate a small iso file which downloads the squashfs file from the specified URI. Due  to current limitations in busyboxs wget and DNS resolution, an URL can not contain a hostname but an IP only. This is useful if you want to boot systems which support booting iso image from your local system. Besides the iso image this command also copies the squashfs file to the output directory.
 


### PR DESCRIPTION
- single dashes don't need to be escaped
- \* has to apear directly after the string
