### PR TITLE
Remove Recommends: isolinux, as the package is gone

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: http://git.grml.org/?p=grml2usb.git
 Package: grml2usb
 Architecture: i386 amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, syslinux | grub-pc, python, rsync, mtools, realpath
-Recommends: syslinux, isolinux, xorriso | genisoimage
+Recommends: syslinux, xorriso | genisoimage
 Description: install Grml system / ISO to usb device
  This script installs a Grml ISO to an USB device to be able
  to boot from it.  Make sure you have at least one Grml ISO


### PR DESCRIPTION
http://packages.debian.org/isolinux
http://qa.debian.org/debcheck.php?dist=testing&package=grml2usb
