### PR TITLE
Feature: Extend search paths for syslinux MBRs

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1584,6 +1584,7 @@ def handle_mbr(device):
     if options.syslinuxmbr:
         mbrcode = ""
         mbr_locations = ('/usr/lib/syslinux/mbr.bin',
+                         '/usr/lib/syslinux/bios/mbr.bin',
                          '/usr/share/syslinux/mbr.bin')
         for mbrpath in mbr_locations:
             if os.path.isfile(mbrpath):


### PR DESCRIPTION
Hi grml team,

attached you can find a PR to extend the search paths for the syslinux MBRs.
ArchLinux for example splits the support of BIOS, EFI 32-bit and 64-bit into different directories:
https://www.archlinux.org/packages/core/x86_64/syslinux/files/

Regards,
JoeKar
