### PR TITLE
Add smoke autopkgtests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Vcs-Browser: https://git.grml.org/?p=grml2usb.git
 
 Package: grml2usb
 Architecture: amd64 i386
-Depends: mtools,
+Depends: kmod,
+         mtools,
          python,
          python-parted,
          rsync,

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,10 @@
+Tests: smoke-grml2usb-py2
+Depends: dosfstools,
+         kpartx,
+         isolinux,
+         python2,
+         syslinux,
+         syslinux-common,
+         xorriso,
+         @
+Restrictions: needs-root, isolation-machine, breaks-testbed

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -8,3 +8,14 @@ Depends: dosfstools,
          xorriso,
          @
 Restrictions: needs-root, isolation-machine, breaks-testbed
+
+Tests: smoke-grml2usb-py3
+Depends: dosfstools,
+         kpartx,
+         isolinux,
+         python2,
+         syslinux,
+         syslinux-common,
+         xorriso,
+         @
+Restrictions: needs-root, isolation-machine, breaks-testbed

--- a/debian/tests/smoke-grml2usb-py2
+++ b/debian/tests/smoke-grml2usb-py2
@@ -1,0 +1,36 @@
+#!/bin/bash
+exec 2>&1
+set -ex
+
+TMPDIR=$(mktemp -d)
+LODEV=$(losetup -f)
+cleanup() {
+  kpartx -d "$LODEV" || true
+  losetup -d "$LODEV" || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir "$TMPDIR"/isoroot "$TMPDIR"/isoroot/boot "$TMPDIR"/isoroot/boot/isolinux
+cp /usr/lib/ISOLINUX/isolinux.bin "$TMPDIR"/isoroot/boot/isolinux/
+echo 'FAKE' > "$TMPDIR"/isoroot/grml-version
+echo 'LOGO' > "$TMPDIR"/isoroot/boot/logo.16
+touch "$TMPDIR"/isoroot/boot/isolinux/FAKE_default.cfg
+touch "$TMPDIR"/isoroot/boot/isolinux/FAKE_grml.cfg
+touch "$TMPDIR"/isoroot/boot/isolinux/hidden.cfg
+xorriso -as mkisofs -l -r -J -no-pad -no-emul-boot -boot-load-size 4 -boot-info-table -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat -o "$TMPDIR"/fake.iso "$TMPDIR"/isoroot
+xorriso -dev "$TMPDIR"/fake.iso -ls
+
+dd if=/dev/zero of="$TMPDIR"/blockdev bs=1M count=50
+
+sfdisk "$TMPDIR"/blockdev <<EOT
+label: dos
+label-id: 0x00000000
+unit: sectors
+
+p1 : start=        2048, size=      100352, type=6, bootable
+EOT
+
+losetup -P "$LODEV" "$TMPDIR"/blockdev
+
+python2 $(which grml2usb) --bootloader-only --verbose --skip-usb-check --force --fat16 "$TMPDIR"/fake.iso "$LODEV"p1

--- a/debian/tests/smoke-grml2usb-py3
+++ b/debian/tests/smoke-grml2usb-py3
@@ -1,0 +1,36 @@
+#!/bin/bash
+exec 2>&1
+set -ex
+
+TMPDIR=$(mktemp -d)
+LODEV=$(losetup -f)
+cleanup() {
+  kpartx -d "$LODEV" || true
+  losetup -d "$LODEV" || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+mkdir "$TMPDIR"/isoroot "$TMPDIR"/isoroot/boot "$TMPDIR"/isoroot/boot/isolinux
+cp /usr/lib/ISOLINUX/isolinux.bin "$TMPDIR"/isoroot/boot/isolinux/
+echo 'FAKE' > "$TMPDIR"/isoroot/grml-version
+echo 'LOGO' > "$TMPDIR"/isoroot/boot/logo.16
+touch "$TMPDIR"/isoroot/boot/isolinux/FAKE_default.cfg
+touch "$TMPDIR"/isoroot/boot/isolinux/FAKE_grml.cfg
+touch "$TMPDIR"/isoroot/boot/isolinux/hidden.cfg
+xorriso -as mkisofs -l -r -J -no-pad -no-emul-boot -boot-load-size 4 -boot-info-table -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat -o "$TMPDIR"/fake.iso "$TMPDIR"/isoroot
+xorriso -dev "$TMPDIR"/fake.iso -ls
+
+dd if=/dev/zero of="$TMPDIR"/blockdev bs=1M count=50
+
+sfdisk "$TMPDIR"/blockdev <<EOT
+label: dos
+label-id: 0x00000000
+unit: sectors
+
+p1 : start=        2048, size=      100352, type=6, bootable
+EOT
+
+losetup -P "$LODEV" "$TMPDIR"/blockdev
+
+python3 $(which grml2usb) --bootloader-only --verbose --skip-usb-check --force --fat16 "$TMPDIR"/fake.iso "$LODEV"p1

--- a/grml2usb
+++ b/grml2usb
@@ -1932,6 +1932,8 @@ def main():
 
     except Exception as error:
         logging.critical("Fatal: %s", str(error))
+        if options.verbose:
+            logging.exception("Exception:")
         sys.exit(1)
 
 

--- a/grml2usb
+++ b/grml2usb
@@ -315,7 +315,7 @@ def get_defaults_file(iso_mount, flavour, name):
     return ('', '')
 
 
-def search_file(filename, search_path='/bin' + os.pathsep + '/usr/bin', lst_return=False):
+def search_file(filename, search_path='/bin' + os.pathsep + '/usr/bin', lst_return=False, required=False):
     """Given a search path, find file
 
     @filename: name of file to search for
@@ -344,6 +344,10 @@ def search_file(filename, search_path='/bin' + os.pathsep + '/usr/bin', lst_retu
                 retval.append(os.path.abspath(os.path.join(current_dir, filename)))
                 if not lst_return:
                     break
+
+    if required and not retval:
+        raise CriticalException("Required file %s not found in %s" % (filename, search_path))
+
     if lst_return:
         return retval
     elif retval:
@@ -1108,7 +1112,7 @@ def copy_bootloader_files(iso_mount, target, grml_flavour):
     grub_target = target + '/boot/grub/'
     execute(mkdir, grub_target)
 
-    logo = search_file('logo.16', iso_mount)
+    logo = search_file('logo.16', iso_mount, required=True)
     exec_rsync(logo, syslinux_target + 'logo.16')
 
     bootx64_efi = search_file('bootx64.efi', iso_mount)


### PR DESCRIPTION
Unfortunately they need machine level isolation, so are not useful for debci.

The test builds a stub/fake ISO with just the minimal files for a syslinux bootloader setup (which itself will not work).

There is one copy of the test for python2, and one for python3. Not happy with the code duplication, but also not sure on which things one can rely inside autopkgtest to improve this.

Moving the package completely over to py3 is not done here.