### PR TITLE
Avoid subprocess.Popen with stdout/stderr=PIPE and wait() usage

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1855,14 +1855,14 @@ def check_programs():
 
 
 def load_loop():
-    """Runs modprobe loop and throws away it's output"""
+    """Runs modprobe loop and throws away its output"""
     if not which("modprobe"):
         logging.critical("Fatal: modprobe not available, can not continue - sorry.")
         logging.critical("Hint: is /sbin missing in PATH?")
         sys.exit(1)
 
     proc = subprocess.Popen(["modprobe", "loop"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    proc.wait()
+    proc.communicate()
 
 
 def main():


### PR DESCRIPTION
Quoting from https://docs.python.org/2/library/subprocess.html#popen-objects:

| Popen.wait()
|   Wait for child process to terminate. Set and return returncode attribute.
|
|   Warning
|   This will deadlock when using stdout=PIPE and/or stderr=PIPE and the child
|   process generates enough output to a pipe such that it blocks waiting for the
|   OS pipe buffer to accept more data. Use communicate() to avoid that.

While modprobe isn't expected to ever output enough output to be
relevant, let's better be safe than sorry.

While at it fix typo (it's -> its)

Closes grml/grml2usb#21