### PR TITLE
Fix path to syslinux *.c32 files

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -41,7 +41,7 @@ DATESTAMP = time.mktime(datetime.datetime.now().timetuple())  # unique identifie
 GRML_FLAVOURS = set()  # which flavours are being installed?
 GRML_DEFAULT = None
 UUID = None
-SYSLINUX_LIBS = "/usr/lib/syslinux/"
+SYSLINUX_LIBS = "/usr/lib/syslinux/modules/bios/"
 GPT_HEADER = b"\x55\xaa\x45\x46\x49\x20\x50\x41\x52\x54"  # original GPT header
 GRUB_INSTALL = None
 


### PR DESCRIPTION
In syslinux version 6.00 their path has changed, and so grml2usb
failed to find the files, using the ones from the grml iso instead.
The result was that the bootloader and its files had mismatched
versions which could lead to errors on boot, see
https://bugs.debian.org/943845.

Since syslinux 6.00 is already over six years old, I did not bother to
check for the *.c32 in the /usr/lib/syslinux/ directory.