### PR TITLE
Check for boot flag before possibly creating FAT16 on the partition

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1875,9 +1875,10 @@ def install_grml(mountpoint, device):
         register_tmpfile(device_mountpoint)
         remove_device_mountpoint = True
         try:
-            check_for_fat(device)
             if not options.skipbootflag:
                 check_boot_flag(device)
+
+            check_for_fat(device)
 
             set_rw(device)
             mount(device, device_mountpoint, ["-o", "utf8,iocharset=iso8859-1"])


### PR DESCRIPTION
Checks should be performed before actually modifying the USB device,
if the user specified `--fat16` then the boot flag should be checked
*before* the FAT filesystem gets created.

Closes: grml/grml2usb#30