### PR TITLE
Check for boot flag before possibly creating FAT16 on the partition

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1875,10 +1875,6 @@ def install_grml(mountpoint, device):
         register_tmpfile(device_mountpoint)
         remove_device_mountpoint = True
         try:
-            check_for_fat(device)
-            if not options.skipbootflag:
-                check_boot_flag(device)
-
             set_rw(device)
             mount(device, device_mountpoint, ["-o", "utf8,iocharset=iso8859-1"])
         except CriticalException:
@@ -2162,6 +2158,9 @@ def main():
 
         # provide upgrade path
         handle_compat_warning(device)
+
+        if not options.skipbootflag:
+            check_boot_flag(device)
 
         # check for vfat partition
         handle_vfat(device)


### PR DESCRIPTION
Checks should be performed before actually modifying the USB device,
if the user specified `--fat16` then the boot flag should be checked
*before* the FAT filesystem gets created.

check_for_fat(device) is called in handle_vfat(device) (if device is
present and not a directory and if option 'syslinux' (default) is set)
so it should be safe to remove check_for_fat(device) call in
install_grml().

The same applies to check_boot_flag() which should happen before
actually creating the FAT filesystem (in handle_vfat()).

Closes: grml/grml2usb#30