### PR TITLE
Fix vulture usage and add vulture to Build-Depends

### DIFF
--- a/.github/workflows/check-full.yml
+++ b/.github/workflows/check-full.yml
@@ -15,15 +15,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Install virtualenv + python3-setuptools
-        run: sudo apt-get install virtualenv python3-setuptools
-
-      - name: Set up Python virtualenv environment
-        run: virtualenv -p /usr/bin/python3 venv3
-
-      - name: Activate Python virtualenv environment
-        run: . ./venv3/bin/activate
-
       - name: pip install wheel (to make install black work)
         run: pip3 install wheel
 
@@ -40,15 +31,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-
-      - name: Install virtualenv + python3-setuptools
-        run: sudo apt-get install virtualenv python3-setuptools
-
-      - name: Set up Python virtualenv environment
-        run: virtualenv -p /usr/bin/python3 venv3
-
-      - name: Activate Python virtualenv environment
-        run: . ./venv3/bin/activate
 
       - name: Install pytest
         run: pip3 install pytest

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ codecheck:
 	flake8 grml2usb
 	isort --check-only grml2usb
 	black --check grml2usb
-	vulture grml2iso grml2usb test/grml2usb_test.py
+	vulture grml2usb test/grml2usb_test.py
 
 test:
 	pytest

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends:
  docbook-xsl,
  flake8,
  isort,
+ vulture,
  xsltproc,
 Standards-Version: 4.5.1
 Homepage: https://grml.org/grml2usb/


### PR DESCRIPTION
This includes the relevant changes to get https://github.com/grml/grml2usb/pull/46 approved:

* grml2iso is a shell script, executing vulture doesn't work on it
* the Debian package build process executes 'make codecheck:', so
  everything what's needed for its execution needs to be covered through
  the Build-Dependencies, accordingly add add vulture to Build-Depends

