### PR TITLE
debian: Do not run codecheck

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,13 +9,9 @@ Uploaders:
  Ulrich Dangel <mru@spamt.net>,
 Build-Depends:
  asciidoc,
- black,
  debhelper-compat (= 12),
  docbook-xsl,
- flake8,
- isort,
  nasm,
- vulture,
  xsltproc,
 Standards-Version: 4.6.2
 Rules-Requires-Root: no

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_build:
 	dh_testdir
 	grep -qE '^PROG_VERSION = "\*\*\*UNKNOWN\*\*\*"' grml2usb || (echo "PROG_VERSION in grml2usb wrong." && exit 2)
 	$(MAKE) -C mbr
-	$(MAKE)
+	$(MAKE) doc
 
 override_dh_fixperms:
 	chmod 664 ./debian/grml2usb/usr/share/grml2usb/mbr/mbrldr


### PR DESCRIPTION
We do not want to depend on these checks succeeding in Debian. They should run in CI and that shall be enough.
