### PR TITLE
Enable workflow_dispatch for check-full workflow

### DIFF
--- a/.github/workflows/check-full.yml
+++ b/.github/workflows/check-full.yml
@@ -1,11 +1,14 @@
 name: Code Testing
-
 on:
-  push:
+  workflow_dispatch:
   pull_request:
+  push:
   schedule:
     - cron: '42 1 * * *'
 
+concurrency:
+  group: "codecheck-${{ github.ref }}"
+  cancel-in-progress: true
 jobs:
   codecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Useful for re-running the codecheck targets on master. This is already enabled on the other workflow.