### PR TITLE
Copy bootaa64.efi if available

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1198,10 +1198,11 @@ def copy_bootloader_files(iso_mount, target, grml_flavour):
     logo = search_file("logo.16", iso_mount, required=True)
     exec_rsync(logo, syslinux_target + "logo.16")
 
-    bootx64_efi = search_file("bootx64.efi", iso_mount)
-    if bootx64_efi:
-        mkdir(target + "/efi/boot/")
-        exec_rsync(bootx64_efi, target + "/efi/boot/bootx64.efi")
+    for filename in ("bootx64.efi", "bootaa64.efi"):
+        efi_loader = search_file("bootx64.efi", iso_mount)
+        if efi_loader:
+            mkdir(target + "/efi/boot/")
+            exec_rsync(efi_loader, target + "/efi/boot/" + filename)
 
     efi_img = search_file("efi.img", iso_mount)
     if efi_img:


### PR DESCRIPTION
Necessary for aarch64 ISOs.