### PR TITLE
Fix crash: expected str, bytes or os.PathLike object, not list

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -236,7 +236,6 @@ parser.add_argument(
 )
 parser.add_argument(
     "device",
-    nargs=1,
     help="Partition on USB Device to install on",
 )
 


### PR DESCRIPTION
Introduced in 2163d31ec126ab47af5fd12a2b8ad04ceb0b72b6.