### PR TITLE
GHA CI: revert back to ubuntu-latest

### DIFF
--- a/.github/workflows/check-full.yml
+++ b/.github/workflows/check-full.yml
@@ -28,7 +28,7 @@ jobs:
         run: make codecheck
 
   unittests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: Run unit tests as root
 
     steps:


### PR DESCRIPTION
Runner image should be new enough to build "mbr". Closes: grml/grml2usb#64