### PR TITLE
grml2usb: follow glob1 deprecation

### DIFF
--- a/grml2usb
+++ b/grml2usb
@@ -1285,7 +1285,7 @@ def copy_bootloader_files(iso_mount, target, grml_flavour):
 
             for modules_dir in options.syslinuxlibs + SYSLINUX_LIBS:
                 if os.path.isdir(modules_dir):
-                    for filename in glob.glob1(syslinux_target, "*.c32"):
+                    for filename in glob.glob("*.c32", root_dir=syslinux_target):
                         copy_if_exist(
                             os.path.join(modules_dir, filename), syslinux_target
                         )


### PR DESCRIPTION
Fixes this deprecation warning from Python 3.14:

```
DeprecationWarning: glob.glob1 is deprecated and will be removed in Python 3.15. Use glob.glob and pass a directory to its root_dir argument instead.
   for filename in glob.glob1(syslinux_target, "*.c32"):
```

As reported in https://github.com/grml/grml-terminalserver/issues/19

Minimum Python version becomes 3.10.