### PR TITLE
Adjust Depends to have grub-pc-bin available when needed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,13 +22,14 @@ X-Style: black
 Package: grml2usb
 Architecture: all
 Depends:
+ grub-efi-amd64-signed | grub-efi-amd64-bin | grub-common,
+ grub-efi-arm64-signed | grub-efi-arm64-bin | grub-common,
+ grub-pc-bin | grub-common,
  kmod,
  mtools,
  python3,
  python3-parted,
  rsync,
- syslinux | grub-common,
- syslinux | grub-efi-amd64-signed | grub-pc-bin | grub-efi-arm64-bin | grub-common,
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:


### PR DESCRIPTION
grub-pc-bin is required at least on amd64, fixes:

```
| /usr/sbin/grub-install: error: /usr/lib/grub/i386-pc/modinfo.sh doesn't exist. Please specify --target or --directory.
| 2026-05-11 15:35:20,168 Running "/usr/sbin/grub-install" "--recheck" "--no-floppy" "--target=i386-pc" "--root-directory=/tmp/grml2usb6zca_m_r" "--force" "/dev/sdd"
| /usr/sbin/grub-install: error: /usr/lib/grub/i386-pc/modinfo.sh doesn't exist. Please specify --target or --directory.
| 2026-05-11 15:35:20,170 Fatal: error executing grub-install (please check the grml2usb FAQ or drop the --grub option)
```

Depend on grub-pc-bin *or* grub-common, to get grub-pc-bin at least on amd64 + i386 (on those archs it's available).

Drop syslinux from Depends, as it's no longer used by default with more recent Grml ISOs (we're using GRUB for both BIOS + EFI boot), but keep it in Recommends.

Closes: https://github.com/grml/grml2usb/issues/112