### PR TITLE
Drop depends on arm64 specific grub packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,6 @@ Package: grml2usb
 Architecture: all
 Depends:
  grub-efi-amd64-signed | grub-efi-amd64-bin | grub-common,
- grub-efi-arm64-signed | grub-efi-arm64-bin | grub-common,
  grub-pc-bin | grub-common,
  kmod,
  mtools,


### PR DESCRIPTION
We don't support GRUB on arm64 (only EFI boot is supported there), so there's no point in providing those depends.